### PR TITLE
don't print SUBCOMMANDS in help unless there's named subcommands

### DIFF
--- a/xflags-macros/src/emit.rs
+++ b/xflags-macros/src/emit.rs
@@ -377,16 +377,19 @@ fn help_rec(buf: &mut String, prefix: &str, cmd: &ast::Cmd) {
         }
     }
 
-    if prefix.is_empty() {
-        blank_line(buf);
-        w!(buf, "SUBCOMANDS:");
-    }
+    let subcommands = cmd.named_subcommands();
+    if !subcommands.is_empty() {
+        if prefix.is_empty() {
+            blank_line(buf);
+            w!(buf, "SUBCOMANDS:");
+        }
 
-    let prefix = format!("{}{} ", prefix, cmd.name);
-    for sub in cmd.named_subcommands() {
-        blank_line(buf);
-        blank_line(buf);
-        help_rec(buf, &prefix, sub);
+        let prefix = format!("{}{} ", prefix, cmd.name);
+        for sub in subcommands {
+            blank_line(buf);
+            blank_line(buf);
+            help_rec(buf, &prefix, sub);
+        }
     }
 }
 

--- a/xflags-macros/src/emit.rs
+++ b/xflags-macros/src/emit.rs
@@ -381,7 +381,7 @@ fn help_rec(buf: &mut String, prefix: &str, cmd: &ast::Cmd) {
     if !subcommands.is_empty() {
         if prefix.is_empty() {
             blank_line(buf);
-            w!(buf, "SUBCOMANDS:");
+            w!(buf, "SUBCOMMANDS:");
         }
 
         let prefix = format!("{}{} ", prefix, cmd.name);


### PR DESCRIPTION
I didn't see any tests for help generation, but it worked on my local machine :upside_down_face: 

Currently `SUBCOMMANDS` is always printed in help. This will only print it if there's named subcommands.

Also fix a typo.