### PR TITLE
allow dead code for generated api

### DIFF
--- a/xflags-macros/src/emit.rs
+++ b/xflags-macros/src/emit.rs
@@ -109,11 +109,13 @@ fn emit_api(buf: &mut String, xflags: &ast::XFlags) {
     w!(buf, "    pub const HELP: &'static str = Self::HELP_;\n");
     blank_line(buf);
 
+    w!(buf, "    #[allow(dead_code)]\n");
     w!(buf, "    pub fn from_env() -> xflags::Result<Self> {{\n");
     w!(buf, "        Self::from_env_()\n");
     w!(buf, "    }}\n");
     blank_line(buf);
 
+    w!(buf, "    #[allow(dead_code)]\n");
     w!(buf, "    pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {{\n");
     w!(buf, "        Self::from_vec_(args)\n");
     w!(buf, "    }}\n");

--- a/xflags-macros/tests/it/help.rs
+++ b/xflags-macros/tests/it/help.rs
@@ -20,10 +20,12 @@ pub struct Sub;
 impl Helpful {
     pub const HELP: &'static str = Self::HELP_;
 
+    #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
         Self::from_env_()
     }
 
+    #[allow(dead_code)]
     pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
         Self::from_vec_(args)
     }

--- a/xflags-macros/tests/it/repeated_pos.rs
+++ b/xflags-macros/tests/it/repeated_pos.rs
@@ -12,10 +12,12 @@ pub struct RepeatedPos {
 impl RepeatedPos {
     pub const HELP: &'static str = Self::HELP_;
 
+    #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
         Self::from_env_()
     }
 
+    #[allow(dead_code)]
     pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
         Self::from_vec_(args)
     }

--- a/xflags-macros/tests/it/smoke.rs
+++ b/xflags-macros/tests/it/smoke.rs
@@ -16,10 +16,12 @@ pub struct RustAnalyzer {
 impl RustAnalyzer {
     pub const HELP: &'static str = Self::HELP_;
 
+    #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
         Self::from_env_()
     }
 
+    #[allow(dead_code)]
     pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
         Self::from_vec_(args)
     }

--- a/xflags-macros/tests/it/subcommands.rs
+++ b/xflags-macros/tests/it/subcommands.rs
@@ -43,10 +43,12 @@ pub struct AnalysisStats {
 impl RustAnalyzer {
     pub const HELP: &'static str = Self::HELP_;
 
+    #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
         Self::from_env_()
     }
 
+    #[allow(dead_code)]
     pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
         Self::from_vec_(args)
     }


### PR DESCRIPTION
Most users would probably only use either `from_env` or `from_vec`,
leaving the other method unused.

Put `allow(dead_code)` on both methods so neither would ever generate a
warning.