### PR TITLE
Extend non-utf8 example for Windows

### DIFF
--- a/examples/non-utf8.rs
+++ b/examples/non-utf8.rs
@@ -1,4 +1,4 @@
-use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+use std::ffi::OsString;
 
 mod flags {
     use std::{ffi::OsString, path::PathBuf};
@@ -13,7 +13,10 @@ mod flags {
     }
 }
 
+#[cfg(unix)]
 fn main() {
+    use std::os::unix::ffi::OsStringExt;
+
     let flags = flags::Cmd::from_vec(vec![
         OsString::from_vec(vec![254].into()),
         OsString::from_vec(vec![255].into()),
@@ -22,3 +25,19 @@ fn main() {
 
     eprintln!("flags = {:?}", flags);
 }
+
+#[cfg(windows)]
+fn main() {
+    use std::os::windows::ffi::OsStringExt;
+
+    let flags = flags::Cmd::from_vec(vec![
+        OsString::from_wide(&[0xD800]),
+        OsString::from_wide(&[0xDC00]),
+        "utf8".into(),
+    ]);
+
+    eprintln!("flags = {:?}", flags);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn main() {}


### PR DESCRIPTION
This PR extends the non-utf8 example for Windows. For platforms `not(any(unix, windows))`, a `fn main() {}` stub is used.
Without this change, running `cargo test` and `cargo run --example non-utf8` leads to build errors while on Windows.

<details>

<summary>build error</summary>

```
cargo test
   Compiling xflags v0.2.1
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> examples\non-utf8.rs:18:18
   |
18 |     use std::os::unix::ffi::OsStringExt;
   |                  ^^^^ could not find `unix` in `os`

error[E0599]: no function or associated item named `from_vec` found for struct `OsString` in the current scope
  --> examples\non-utf8.rs:21:19
   |
21 |         OsString::from_vec(vec![254].into()),
   |                   ^^^^^^^^ function or associated item not found in `OsString`

error[E0599]: no function or associated item named `from_vec` found for struct `OsString` in the current scope
  --> examples\non-utf8.rs:22:19
   |
22 |         OsString::from_vec(vec![255].into()),
   |                   ^^^^^^^^ function or associated item not found in `OsString`

error: aborting due to 3 previous errors
```

</details>