### PR TITLE
Rough cut at enum generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xflags"
-version = "0.2.1" # NB: update me in 3 places
+version = "0.2.2" # NB: update me in 3 places
 description = "Moderately simple command line arguments parser."
 categories = ["command-line-interface"]
 license = "MIT OR Apache-2.0"
@@ -14,4 +14,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml"]
 members = ["xtask", "xflags-macros"]
 
 [dependencies]
-xflags-macros = { path = "./xflags-macros", version = "=0.2.1" }
+xflags-macros = { path = "./xflags-macros", version = "=0.2.2" }

--- a/xflags-macros/Cargo.toml
+++ b/xflags-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xflags-macros"
-version = "0.2.1"
+version = "0.2.2"
 description = "Private implementation details of xflags."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xflags"

--- a/xflags-macros/src/ast.rs
+++ b/xflags-macros/src/ast.rs
@@ -30,6 +30,12 @@ pub(crate) struct Flag {
     pub(crate) val: Option<Val>,
 }
 
+#[derive(Debug)]
+pub(crate) struct Enum {
+    pub(crate) name: String,
+    pub(crate) variants: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Arity {
     Optional,
@@ -48,4 +54,5 @@ pub(crate) enum Ty {
     PathBuf,
     OsString,
     FromStr(String),
+    Enum(Enum),
 }

--- a/xflags-macros/src/emit.rs
+++ b/xflags-macros/src/emit.rs
@@ -331,10 +331,20 @@ fn emit_help(buf: &mut String, xflags: &ast::XFlags) {
     w!(buf, "}}\n");
 }
 
+fn write_lines_indented(buf: &mut String, multiline_str: &str, indent: usize) {
+    for line in multiline_str.split('\n').map(str::trim_end) {
+        if line.is_empty() {
+            w!(buf, "\n")
+        } else {
+            w!(buf, "{blank:indent$}{}\n", line, indent = indent, blank = "");
+        }
+    }
+}
+
 fn help_rec(buf: &mut String, prefix: &str, cmd: &ast::Cmd) {
     w!(buf, "{}{}\n", prefix, cmd.name);
     if let Some(doc) = &cmd.doc {
-        w!(buf, "  {}\n", doc)
+        write_lines_indented(buf, doc, 2);
     }
     let indent = if prefix.is_empty() { "" } else { "  " };
 
@@ -355,7 +365,7 @@ fn help_rec(buf: &mut String, prefix: &str, cmd: &ast::Cmd) {
             };
             w!(buf, "    {}{}{}\n", l, arg.val.name, r);
             if let Some(doc) = &arg.doc {
-                w!(buf, "      {}\n", doc)
+                write_lines_indented(buf, doc, 6)
             }
         }
     }
@@ -374,7 +384,7 @@ fn help_rec(buf: &mut String, prefix: &str, cmd: &ast::Cmd) {
             let value = flag.val.as_ref().map(|it| format!(" <{}>", it.name)).unwrap_or_default();
             w!(buf, "    {}--{}{}\n", short, flag.name, value);
             if let Some(doc) = &flag.doc {
-                w!(buf, "      {}\n", doc)
+                write_lines_indented(buf, doc, 6);
             }
         }
     }

--- a/xflags-macros/src/parse.rs
+++ b/xflags-macros/src/parse.rs
@@ -155,7 +155,7 @@ fn ty(p: &mut Parser) -> Result<ast::Ty> {
     Ok(res)
 }
 
-fn opt_doc(p: &mut Parser) -> Result<Option<String>> {
+fn opt_single_doc(p: &mut Parser) -> Result<Option<String>> {
     if !p.eat_punct('#') {
         return Ok(None);
     }
@@ -168,6 +168,18 @@ fn opt_doc(p: &mut Parser) -> Result<Option<String>> {
     }
     p.exit_delim()?;
     Ok(Some(res))
+}
+
+fn opt_doc(p: &mut Parser) -> Result<Option<String>> {
+    let lines =
+        core::iter::from_fn(|| opt_single_doc(p).transpose()).collect::<Result<Vec<String>>>()?;
+    let lines = lines.join("\n");
+
+    if lines.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(lines))
+    }
 }
 
 fn cmd_name(p: &mut Parser) -> Result<String> {

--- a/xflags-macros/src/parse.rs
+++ b/xflags-macros/src/parse.rs
@@ -124,7 +124,7 @@ fn opt_val(p: &mut Parser) -> Result<Option<ast::Val>, Error> {
 
     let name = p.expect_name()?;
     p.expect_punct(':')?;
-    let ty = ty(p)?;
+    let ty = ty(p, &name)?;
     let res = ast::Val { name, ty };
     Ok(Some(res))
 }
@@ -145,11 +145,22 @@ fn arity(p: &mut Parser) -> Result<ast::Arity> {
     bail!("expected one of `optional`, `required`, `repeated`, got {:?}", p.ts.pop())
 }
 
-fn ty(p: &mut Parser) -> Result<ast::Ty> {
+fn ty(p: &mut Parser, field: &str) -> Result<ast::Ty> {
     let name = p.expect_name()?;
     let res = match name.as_str() {
         "PathBuf" => ast::Ty::PathBuf,
         "OsString" => ast::Ty::OsString,
+        _ if p.eat_punct('|') => {
+            let mut e = ast::Enum { name: field.into(), variants: vec![name] };
+            loop {
+                let variant = p.expect_name()?;
+                e.variants.push(variant);
+                if !p.eat_punct('|') {
+                    break;
+                }
+            }
+            ast::Ty::Enum(e)
+        }
         _ => ast::Ty::FromStr(name),
     };
     Ok(res)

--- a/xflags-macros/tests/it/help.rs
+++ b/xflags-macros/tests/it/help.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsString, path::PathBuf};
 
 #[derive(Debug)]
 pub struct Helpful {
-    pub src: Option<PathBut>,
+    pub src: Option<PathBuf>,
 
     pub switch: (),
     pub subcommand: HelpfulCmd,
@@ -64,7 +64,7 @@ impl Helpful {
                         _ => (),
                     }
                     if let (done_ @ false, buf_) = &mut src {
-                        buf_.push(p_.value_from_str::<PathBut>("src", arg_)?);
+                        buf_.push(arg_.into());
                         *done_ = true;
                         continue;
                     }

--- a/xflags-macros/tests/it/help.rs
+++ b/xflags-macros/tests/it/help.rs
@@ -123,7 +123,7 @@ ARGS:
     [extra]
       Another arg.
 
-      This time, there's some extra info about the
+      This time, we provide some extra info about the
       arg. Maybe some caveats, or what kinds of
       values are accepted.
 

--- a/xflags-macros/tests/it/main.rs
+++ b/xflags-macros/tests/it/main.rs
@@ -1,6 +1,7 @@
 mod repeated_pos;
 mod smoke;
 mod subcommands;
+mod help;
 
 use std::{ffi::OsString, fmt};
 

--- a/xflags-macros/tests/it/main.rs
+++ b/xflags-macros/tests/it/main.rs
@@ -38,6 +38,7 @@ fn smoke() {
                 number: 92,
                 data: [],
                 emoji: false,
+                malloc: None,
             }
         "#]],
     );
@@ -58,6 +59,7 @@ fn smoke() {
                     "0xBEEF",
                 ],
                 emoji: false,
+                malloc: None,
             }
         "#]],
     );

--- a/xflags-macros/tests/it/src/help.rs
+++ b/xflags-macros/tests/it/src/help.rs
@@ -11,9 +11,14 @@ xflags! {
         /// arg. Maybe some caveats, or what kinds of
         /// values are accepted.
         optional extra: String
+        /// This arg will become an enum.
+        optional channel: lts | stable | beta | nightly | dev
     {
         /// And a switch.
         required -s, --switch
+
+        /// A list of allocators you happen to like.
+        repeated --malloc mallocs: mimalloc | jemalloc | sys
 
         /// And even a subcommand!
         cmd sub {

--- a/xflags-macros/tests/it/src/help.rs
+++ b/xflags-macros/tests/it/src/help.rs
@@ -2,7 +2,7 @@ xflags! {
     /// Does stuff
     cmd helpful
         /// With an arg.
-        optional src: PathBut
+        optional src: PathBuf
     {
         /// And a switch.
         required -s, --switch

--- a/xflags-macros/tests/it/src/help.rs
+++ b/xflags-macros/tests/it/src/help.rs
@@ -1,14 +1,25 @@
 xflags! {
     /// Does stuff
+    ///
+    /// Helpful stuff.
     cmd helpful
         /// With an arg.
         optional src: PathBuf
+        /// Another arg.
+        ///
+        /// This time, there's some extra info about the
+        /// arg. Maybe some caveats, or what kinds of
+        /// values are accepted.
+        optional extra: String
     {
         /// And a switch.
         required -s, --switch
 
         /// And even a subcommand!
         cmd sub {
+            /// With an optional flag. This has a really long
+            /// description which spans multiple lines.
+            optional -f, --flag
         }
     }
 }

--- a/xflags-macros/tests/it/src/help.rs
+++ b/xflags-macros/tests/it/src/help.rs
@@ -7,7 +7,7 @@ xflags! {
         optional src: PathBuf
         /// Another arg.
         ///
-        /// This time, there's some extra info about the
+        /// This time, we provide some extra info about the
         /// arg. Maybe some caveats, or what kinds of
         /// values are accepted.
         optional extra: String

--- a/xflags-macros/tests/it/src/smoke.rs
+++ b/xflags-macros/tests/it/src/smoke.rs
@@ -11,5 +11,6 @@ xflags! {
         required -n, --number n: u32
         repeated --data value: OsString
         optional --emoji
+        optional --malloc malloc: jemalloc | mimalloc | sys
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,7 +51,7 @@ fn try_main() -> Result<()> {
 fn print_usage() {
     eprintln!(
         "\
-Usage: cargo run -p xtask <SUBCOMMAND>
+Usage: cargo run -p xtask -- <SUBCOMMAND>
 
 SUBCOMMANDS:
     ci


### PR DESCRIPTION
This branch is forked off of #15, so most of the first commits are from that (githubs UI handles this poorly). I'll rebase after that merges, which will fix the issue. Until then, the last commit of this is actually where the meat is.

This takes a stab at implementing enum support. I think it supports most common uses, although I haven't tested it exhaustively.

That said, it's kind not the best and I'm unsure how I feel about it:

- The `visit_enums` thing is probably the wrong approach and likely can be simplified.
- `Ty::Enum` is unlike the other `Ty` variants in a bunch of ways and code usually either
    - ignores all the other Ty variants excapt enum,
    - or wants to treat enum essentially the same as any other FromStr (which it basically is)
- I'd also vaguely like to have a deduping these.
	- I've had this for things like `--format format: text | json | csv`.
    - As the code is now you probably can probably hack around this by using the of the enum we generate for all-but-one use, and have most stuff work well (except for docs).
	- A challenge here is that in this patch, the enum always inherits the typename from the field its used for.

I don't know how many of these are worth fixing, and how many are deliberate wontfixes (and how many are worth fixing someday but not urgently). I think it's probably a mix, tbh (I just felt like it was worth writing this stuff out while I still had it).

Anyway, I'm done poking at this at the moment, and figured I'd push it up for now.