### PR TITLE
simplify syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ mod flags {
     xflags::xflags! {
         src "./examples/basic.rs"
 
-        cmd my-command
+        cmd my-command {
             required path: PathBuf
-        {
             optional -v, --verbose
         }
     }

--- a/crates/xflags-macros/src/lib.rs
+++ b/crates/xflags-macros/src/lib.rs
@@ -8,8 +8,10 @@ pub fn xflags(_ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // Stub out the code, but let rust-analyzer resolve the invocation
     #[cfg(not(test))]
     {
-        let cmd = parse::parse(_ts).unwrap();
-        let text = emit::emit(&cmd);
+        let text = match parse::parse(_ts) {
+            Ok(cmd) => emit::emit(&cmd),
+            Err(err) => format!("compile_error!(\"invalid flags syntax, {err}\");"),
+        };
         text.parse().unwrap()
     }
     #[cfg(test)]

--- a/crates/xflags-macros/tests/data/help.rs
+++ b/crates/xflags-macros/tests/data/help.rs
@@ -2,16 +2,17 @@ xflags! {
     /// Does stuff
     ///
     /// Helpful stuff.
-    cmd helpful
+    cmd helpful {
         /// With an arg.
         optional src: PathBuf
+
         /// Another arg.
         ///
         /// This time, we provide some extra info about the
         /// arg. Maybe some caveats, or what kinds of
         /// values are accepted.
         optional extra: String
-    {
+
         /// And a switch.
         required -s, --switch
 

--- a/crates/xflags-macros/tests/data/repeated_pos.rs
+++ b/crates/xflags-macros/tests/data/repeated_pos.rs
@@ -1,9 +1,8 @@
 xflags! {
-    cmd RepeatedPos
+    cmd RepeatedPos {
         required a: PathBuf
         optional b: u32
         optional c: OsString
         repeated rest: OsString
-    {
     }
 }

--- a/crates/xflags-macros/tests/data/smoke.rs
+++ b/crates/xflags-macros/tests/data/smoke.rs
@@ -1,10 +1,9 @@
 xflags! {
     /// LSP server for rust.
-    cmd rust-analyzer
+    cmd rust-analyzer {
         required workspace: PathBuf
         /// Number of concurrent jobs.
         optional jobs: u32
-    {
         /// Path to log file. By default, logs go to stderr.
         optional --log-file path: PathBuf
         repeated -v, --verbose

--- a/crates/xflags-macros/tests/data/subcommands.rs
+++ b/crates/xflags-macros/tests/data/subcommands.rs
@@ -11,9 +11,8 @@ xflags! {
             }
         }
 
-        cmd analysis-stats
+        cmd analysis-stats {
             required path: PathBuf
-        {
             optional --parallel
         }
     }

--- a/crates/xflags/examples/hello-generated.rs
+++ b/crates/xflags/examples/hello-generated.rs
@@ -5,10 +5,10 @@ mod flags {
         src "./examples/hello-generated.rs"
 
         /// Prints a greeting.
-        cmd hello
+        cmd hello {
             /// Whom to greet.
             required name: String
-        {
+
             /// Use non-ascii symbols in the output.
             optional -e, --emoji
         }
@@ -27,10 +27,12 @@ mod flags {
     impl Hello {
         pub const HELP: &'static str = Self::HELP_;
 
+        #[allow(dead_code)]
         pub fn from_env() -> xflags::Result<Self> {
             Self::from_env_()
         }
 
+        #[allow(dead_code)]
         pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
             Self::from_vec_(args)
         }

--- a/crates/xflags/examples/hello.rs
+++ b/crates/xflags/examples/hello.rs
@@ -1,8 +1,7 @@
 mod flags {
     xflags::xflags! {
-        cmd hello
+        cmd hello {
             required name: String
-        {
             optional -e, --emoji
         }
     }

--- a/crates/xflags/examples/longer.rs
+++ b/crates/xflags/examples/longer.rs
@@ -24,10 +24,9 @@ mod flags {
             }
 
             /// Benchmark specific analysis operation
-            cmd analysis-bench
+            cmd analysis-bench {
                 /// Directory with Cargo.toml
                 optional path: PathBuf
-            {
                 /// Compute syntax highlighting for this file
                 required --highlight path: PathBuf
                 /// Compute highlighting for this line

--- a/crates/xflags/examples/non-utf8.rs
+++ b/crates/xflags/examples/non-utf8.rs
@@ -4,11 +4,10 @@ mod flags {
     use std::{ffi::OsString, path::PathBuf};
 
     xflags::xflags! {
-        cmd Cmd
+        cmd Cmd {
             required a: OsString
             required b: PathBuf
             required c: String
-        {
         }
     }
 }

--- a/crates/xflags/src/lib.rs
+++ b/crates/xflags/src/lib.rs
@@ -27,9 +27,8 @@
 //!     xflags::xflags! {
 //!         src "./examples/basic.rs"
 //!
-//!         cmd my-command
+//!         cmd my-command {
 //!             required path: PathBuf
-//!         {
 //!             optional -v, --verbose
 //!         }
 //!     }
@@ -110,16 +109,16 @@
 //! }
 //! ```
 //!
-//! Positional arguments are specified before the opening curly brace:
+//! Arguments without `--` in then ame are positional.
 //!
 //! ```
 //! use std::{path::PathBuf, ffi::OsString};
 //!
 //! xflags::xflags! {
-//!     cmd positional-arguments
+//!     cmd positional-arguments {
 //!         required program: PathBuf
 //!         repeated args: OsString
-//!     { }
+//!     }
 //! }
 //! ```
 //!
@@ -204,8 +203,8 @@
 //! }
 //! ```
 //!
-//! Commands, arguments, and switches can documented. Doc comments become a part
-//! of generated help:
+//! Commands, arguments, and switches can be documented. Doc comments become a
+//! part of generated help:
 //!
 //! ```
 //! mod flags {
@@ -213,10 +212,9 @@
 //!
 //!     xflags::xflags! {
 //!         /// Run basic system diagnostics.
-//!         cmd healthck
+//!         cmd healthck {
 //!             /// Optional configuration file.
 //!             optional config: PathBuf
-//!         {
 //!             /// Verbosity level, can be repeated multiple times.
 //!             repeated -v, --verbose
 //!             /// Print the help message.


### PR DESCRIPTION
There's no need for "positional arguments go before {" rule `--` is enough to disambiguate the two cases.

bors r+