### PR TITLE
handle `-h,--help` automatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["xtask/", "crates/*"]
 
 [workspace.package]
-version = "0.3.0-pre.1" # NB: update the dep!
+version = "0.3.0-pre.2" # NB: update the dep!
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xflags"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/crates/xflags-macros/src/ast.rs
+++ b/crates/xflags-macros/src/ast.rs
@@ -37,6 +37,12 @@ pub(crate) struct Flag {
     pub(crate) val: Option<Val>,
 }
 
+impl Flag {
+    pub(crate) fn is_help(&self) -> bool {
+        self.name == "help"
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Arity {
     Optional,

--- a/crates/xflags-macros/src/parse.rs
+++ b/crates/xflags-macros/src/parse.rs
@@ -28,6 +28,7 @@ pub(crate) fn xflags(ts: TokenStream) -> Result<ast::XFlags> {
     let doc = opt_doc(p)?;
     let mut cmd = cmd(p)?;
     cmd.doc = doc;
+    add_help(&mut cmd);
     let res = ast::XFlags { src, cmd };
     Ok(res)
 }
@@ -36,6 +37,12 @@ pub(crate) fn parse_or_exit(ts: TokenStream) -> Result<ast::XFlags> {
     let p = &mut Parser::new(ts);
     let mut cmd = anon_cmd(p)?;
     assert!(cmd.subcommands.is_empty());
+    add_help(&mut cmd);
+    let res = ast::XFlags { src: None, cmd };
+    Ok(res)
+}
+
+fn add_help(cmd: &mut ast::Cmd) {
     let help = ast::Flag {
         arity: ast::Arity::Optional,
         name: "help".to_string(),
@@ -44,8 +51,6 @@ pub(crate) fn parse_or_exit(ts: TokenStream) -> Result<ast::XFlags> {
         val: None,
     };
     cmd.flags.push(help);
-    let res = ast::XFlags { src: None, cmd };
-    Ok(res)
 }
 
 macro_rules! format_err {
@@ -148,6 +153,10 @@ fn flag(p: &mut Parser, name: String) -> Result<ast::Flag> {
         if !long.starts_with("--") {
             bail!("long name must begin with `--`: `{long}`");
         }
+    }
+
+    if long == "--help" {
+        bail!("`--help` flag is generated automatically")
     }
 
     let val = opt_val(p)?;

--- a/crates/xflags-macros/tests/it/help.rs
+++ b/crates/xflags-macros/tests/it/help.rs
@@ -21,7 +21,10 @@ pub struct Sub {
 }
 
 impl Helpful {
-    pub const HELP: &'static str = Self::HELP_;
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
     #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
@@ -35,6 +38,9 @@ impl Helpful {
 }
 
 impl Helpful {
+    fn from_env_or_exit_() -> Self {
+        Self::from_env_().unwrap_or_else(|err| err.exit())
+    }
     fn from_env_() -> xflags::Result<Self> {
         let mut p = xflags::rt::Parser::new_from_env();
         Self::parse_(&mut p)
@@ -58,6 +64,7 @@ impl Helpful {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0 | 1, "--switch" | "-s") => switch.push(()),
+                    (0 | 1, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     (1, "--flag" | "-f") => sub__flag.push(()),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
@@ -112,6 +119,9 @@ ARGS:
 OPTIONS:
     -s, --switch
       And a switch.
+
+    -h, --help
+      Prints help information.
 
 SUBCOMMANDS:
 

--- a/crates/xflags-macros/tests/it/repeated_pos.rs
+++ b/crates/xflags-macros/tests/it/repeated_pos.rs
@@ -10,7 +10,10 @@ pub struct RepeatedPos {
 }
 
 impl RepeatedPos {
-    pub const HELP: &'static str = Self::HELP_;
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
     #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
@@ -24,6 +27,9 @@ impl RepeatedPos {
 }
 
 impl RepeatedPos {
+    fn from_env_or_exit_() -> Self {
+        Self::from_env_().unwrap_or_else(|err| err.exit())
+    }
     fn from_env_() -> xflags::Result<Self> {
         let mut p = xflags::rt::Parser::new_from_env();
         Self::parse_(&mut p)
@@ -46,6 +52,7 @@ impl RepeatedPos {
         while let Some(arg_) = p_.pop_flag() {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
+                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
@@ -95,5 +102,9 @@ ARGS:
     [c]
 
     <rest>...
+
+OPTIONS:
+    -h, --help
+      Prints help information.
 ";
 }

--- a/crates/xflags-macros/tests/it/smoke.rs
+++ b/crates/xflags-macros/tests/it/smoke.rs
@@ -14,7 +14,10 @@ pub struct RustAnalyzer {
 }
 
 impl RustAnalyzer {
-    pub const HELP: &'static str = Self::HELP_;
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
     #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
@@ -28,6 +31,9 @@ impl RustAnalyzer {
 }
 
 impl RustAnalyzer {
+    fn from_env_or_exit_() -> Self {
+        Self::from_env_().unwrap_or_else(|err| err.exit())
+    }
     fn from_env_() -> xflags::Result<Self> {
         let mut p = xflags::rt::Parser::new_from_env();
         Self::parse_(&mut p)
@@ -58,6 +64,7 @@ impl RustAnalyzer {
                     (0, "--number" | "-n") => number.push(p_.next_value_from_str::<u32>(&flag_)?),
                     (0, "--data") => data.push(p_.next_value(&flag_)?.into()),
                     (0, "--emoji") => emoji.push(()),
+                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
@@ -111,5 +118,8 @@ OPTIONS:
     --data <value>
 
     --emoji
+
+    -h, --help
+      Prints help information.
 ";
 }

--- a/crates/xflags-macros/tests/it/subcommands.rs
+++ b/crates/xflags-macros/tests/it/subcommands.rs
@@ -41,7 +41,10 @@ pub struct AnalysisStats {
 }
 
 impl RustAnalyzer {
-    pub const HELP: &'static str = Self::HELP_;
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
     #[allow(dead_code)]
     pub fn from_env() -> xflags::Result<Self> {
@@ -55,6 +58,9 @@ impl RustAnalyzer {
 }
 
 impl RustAnalyzer {
+    fn from_env_or_exit_() -> Self {
+        Self::from_env_().unwrap_or_else(|err| err.exit())
+    }
     fn from_env_() -> xflags::Result<Self> {
         let mut p = xflags::rt::Parser::new_from_env();
         Self::parse_(&mut p)
@@ -79,6 +85,7 @@ impl RustAnalyzer {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0 | 1 | 2 | 3 | 4, "--verbose" | "-v") => verbose.push(()),
+                    (0 | 1 | 2 | 3 | 4, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     (1 | 2 | 3, "--dir") => server__dir.push(p_.next_value(&flag_)?.into()),
                     (1, _) => {
                         p_.push_back(Ok(flag_));
@@ -140,6 +147,9 @@ rust-analyzer
 
 OPTIONS:
     -v, --verbose
+
+    -h, --help
+      Prints help information.
 
 SUBCOMMANDS:
 

--- a/crates/xflags/Cargo.toml
+++ b/crates/xflags/Cargo.toml
@@ -10,4 +10,4 @@ edition.workspace = true
 
 
 [dependencies]
-xflags-macros = { path = "../xflags-macros", version = "=0.3.0-pre.1" }
+xflags-macros = { path = "../xflags-macros", version = "=0.3.0-pre.2" }

--- a/crates/xflags/examples/hello-generated.rs
+++ b/crates/xflags/examples/hello-generated.rs
@@ -25,8 +25,6 @@ mod flags {
     }
 
     impl Hello {
-        pub const HELP: &'static str = Self::HELP_;
-
         #[allow(dead_code)]
         pub fn from_env() -> xflags::Result<Self> {
             Self::from_env_()
@@ -46,9 +44,6 @@ fn main() {
             let bang = if flags.emoji { "❣️" } else { "!" };
             println!("Hello {}{}", flags.name, bang);
         }
-        Err(err) => {
-            eprintln!("{}\n\n{}", err, flags::Hello::HELP);
-            std::process::exit(1)
-        }
+        Err(err) => err.exit(),
     }
 }

--- a/crates/xflags/examples/longer.rs
+++ b/crates/xflags/examples/longer.rs
@@ -71,12 +71,12 @@ mod flags {
     }
 
     impl RustAnalyzer {
-        pub const HELP: &'static str = Self::HELP_;
-
+        #[allow(dead_code)]
         pub fn from_env() -> xflags::Result<Self> {
             Self::from_env_()
         }
 
+        #[allow(dead_code)]
         pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
             Self::from_vec_(args)
         }

--- a/crates/xflags/src/rt.rs
+++ b/crates/xflags/src/rt.rs
@@ -4,7 +4,7 @@ use crate::{Error, Result};
 
 macro_rules! format_err {
     ($($tt:tt)*) => {
-        Error { msg: format!($($tt)*) }
+        Error { msg: format!($($tt)*), help: false }
     };
 }
 
@@ -96,6 +96,10 @@ impl Parser {
 
     pub fn subcommand_required(&self) -> Error {
         format_err!("subcommand is required")
+    }
+
+    pub fn help(&self, help: &'static str) -> Error {
+        Error { msg: help.to_string(), help: true }
     }
 
     pub fn optional<T>(&self, flag: &str, mut vals: Vec<T>) -> Result<Option<T>> {


### PR DESCRIPTION
Originally, I was reluctant to put `std::process::exit` in the library, but two observations finally swayed me:

* Adding `_or_exit` to the name goes along way in dispelling concerns about magical behavior
* Looking at the "why" of xflags, we should prioritize convenience over control.