### PR TITLE
add an `alias` keyword to the parser

### DIFF
--- a/crates/xflags-macros/src/ast.rs
+++ b/crates/xflags-macros/src/ast.rs
@@ -13,6 +13,7 @@ impl XFlags {
 #[derive(Debug)]
 pub(crate) struct Cmd {
     pub(crate) name: String,
+    pub(crate) aliases: Vec<String>,
     pub(crate) doc: Option<String>,
     pub(crate) args: Vec<Arg>,
     pub(crate) flags: Vec<Flag>,

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -242,7 +242,8 @@ fn emit_match_flag_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
 
 fn emit_match_arg_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
     for sub in cmd.named_subcommands() {
-        let sub_match = sub.all_identifiers().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(" | ");
+        let sub_match =
+            sub.all_identifiers().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(" | ");
         w!(buf, "({}, {}) => state_ = {},\n", cmd.idx, sub_match, sub.idx);
     }
     if !cmd.args.is_empty() || cmd.has_subcommands() {

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -242,7 +242,8 @@ fn emit_match_flag_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
 
 fn emit_match_arg_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
     for sub in cmd.named_subcommands() {
-        w!(buf, "({}, \"{}\") => state_ = {},\n", cmd.idx, sub.name, sub.idx);
+        let sub_match = sub.all_identifiers().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(" | ");
+        w!(buf, "({}, {}) => state_ = {},\n", cmd.idx, sub_match, sub.idx);
     }
     if !cmd.args.is_empty() || cmd.has_subcommands() {
         w!(buf, "({}, _) => {{\n", cmd.idx);
@@ -406,7 +407,8 @@ fn help_rec(buf: &mut String, prefix: &str, cmd: &ast::Cmd) {
     let mut empty_help = true;
     if !cmd.name.is_empty() {
         empty_help = false;
-        w!(buf, "{}{}\n", prefix, cmd.name);
+        let idens = cmd.all_identifiers().cloned().collect::<Vec<_>>().join(" | ");
+        w!(buf, "{}{}\n", prefix, idens);
     }
     if let Some(doc) = &cmd.doc {
         empty_help = false;
@@ -482,6 +484,9 @@ impl ast::Cmd {
             return "Flags".to_string();
         }
         camel(&self.name)
+    }
+    pub(crate) fn all_identifiers(&self) -> impl Iterator<Item = &String> {
+        [&self.name].into_iter().chain(self.aliases.iter())
     }
     fn cmd_enum_ident(&self) -> String {
         format!("{}Cmd", self.ident())

--- a/crates/xflags-macros/src/parse.rs
+++ b/crates/xflags-macros/src/parse.rs
@@ -144,7 +144,7 @@ fn cmd_impl(p: &mut Parser, anon: bool) -> Result<ast::Cmd> {
     }
 
     let mut unique_identifiers = std::collections::HashSet::new();
-    
+
     for ident in res.subcommands.iter().map(|cmd| cmd.all_identifiers()).flatten() {
         if !unique_identifiers.insert(ident) {
             bail!("`{}` is defined multiple times", ident)

--- a/crates/xflags-macros/src/parse.rs
+++ b/crates/xflags-macros/src/parse.rs
@@ -82,11 +82,18 @@ fn cmd_impl(p: &mut Parser, anon: bool) -> Result<ast::Cmd> {
         cmd_name(p)?
     };
 
+    let aliases = if p.eat_keyword("alias") {
+        alias_names(p)?
+    } else {
+        vec![]
+    };
+
     let idx = p.idx;
     p.idx += 1;
 
     let mut res = ast::Cmd {
         name,
+        aliases,
         doc: None,
         args: Vec::new(),
         flags: Vec::new(),
@@ -135,6 +142,15 @@ fn cmd_impl(p: &mut Parser, anon: bool) -> Result<ast::Cmd> {
     if !anon {
         p.exit_delim()?;
     }
+
+    let mut unique_identifiers = std::collections::HashSet::new();
+    
+    for ident in res.subcommands.iter().map(|cmd| cmd.all_identifiers()).flatten() {
+        if !unique_identifiers.insert(ident) {
+            bail!("`{}` is defined multiple times", ident)
+        }
+    }
+
     Ok(res)
 }
 
@@ -240,6 +256,16 @@ fn cmd_name(p: &mut Parser) -> Result<String> {
         bail!("command name can't begin with `-`: `{name}`");
     }
     Ok(name)
+}
+
+fn alias_names(p: &mut Parser) -> Result<Vec<String>> {
+    let mut aliases = vec![p.expect_name()?];
+
+    while let Some(alias) = p.eat_name() {
+        aliases.push(alias);
+    }
+
+    Ok(aliases)
 }
 
 fn flag_name(p: &mut Parser) -> Result<String> {

--- a/crates/xflags-macros/src/parse.rs
+++ b/crates/xflags-macros/src/parse.rs
@@ -82,11 +82,7 @@ fn cmd_impl(p: &mut Parser, anon: bool) -> Result<ast::Cmd> {
         cmd_name(p)?
     };
 
-    let aliases = if p.eat_keyword("alias") {
-        alias_names(p)?
-    } else {
-        vec![]
-    };
+    let aliases = alias_names(p);
 
     let idx = p.idx;
     p.idx += 1;
@@ -258,14 +254,14 @@ fn cmd_name(p: &mut Parser) -> Result<String> {
     Ok(name)
 }
 
-fn alias_names(p: &mut Parser) -> Result<Vec<String>> {
-    let mut aliases = vec![p.expect_name()?];
+fn alias_names(p: &mut Parser) -> Vec<String> {
+    let mut aliases = vec![];
 
     while let Some(alias) = p.eat_name() {
         aliases.push(alias);
     }
 
-    Ok(aliases)
+    aliases
 }
 
 fn flag_name(p: &mut Parser) -> Result<String> {

--- a/crates/xflags-macros/tests/data/aliases.rs
+++ b/crates/xflags-macros/tests/data/aliases.rs
@@ -1,0 +1,11 @@
+xflags! {
+    /// commands with different aliases
+    cmd alias-cmd {
+        /// And even an aliased subcommand!
+        cmd sub s {
+            /// Little sanity check to see if this still works as intended
+            optional -c, --count count: usize
+        }
+        cmd this one has a lot of aliases {}
+    }
+}

--- a/crates/xflags-macros/tests/it/aliases.rs
+++ b/crates/xflags-macros/tests/it/aliases.rs
@@ -1,0 +1,109 @@
+#![allow(unused)]
+use std::{ffi::OsString, path::PathBuf};
+
+#[derive(Debug)]
+pub struct AliasCmd {
+    pub subcommand: AliasCmdCmd,
+}
+
+#[derive(Debug)]
+pub enum AliasCmdCmd {
+    Sub(Sub),
+    This(This),
+}
+
+#[derive(Debug)]
+pub struct Sub {
+    pub count: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct This;
+
+impl AliasCmd {
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
+
+    #[allow(dead_code)]
+    pub fn from_env() -> xflags::Result<Self> {
+        Self::from_env_()
+    }
+
+    #[allow(dead_code)]
+    pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
+        Self::from_vec_(args)
+    }
+}
+
+impl AliasCmd {
+    fn from_env_or_exit_() -> Self {
+        Self::from_env_().unwrap_or_else(|err| err.exit())
+    }
+    fn from_env_() -> xflags::Result<Self> {
+        let mut p = xflags::rt::Parser::new_from_env();
+        Self::parse_(&mut p)
+    }
+    fn from_vec_(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
+        let mut p = xflags::rt::Parser::new(args);
+        Self::parse_(&mut p)
+    }
+}
+
+impl AliasCmd {
+    fn parse_(p_: &mut xflags::rt::Parser) -> xflags::Result<Self> {
+        #![allow(non_snake_case)]
+        let mut sub__count = Vec::new();
+
+        let mut state_ = 0u8;
+        while let Some(arg_) = p_.pop_flag() {
+            match arg_ {
+                Ok(flag_) => match (state_, flag_.as_str()) {
+                    (0 | 1 | 2, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
+                    (1, "--count" | "-c") => {
+                        sub__count.push(p_.next_value_from_str::<usize>(&flag_)?)
+                    }
+                    _ => return Err(p_.unexpected_flag(&flag_)),
+                },
+                Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
+                    (0, "sub" | "s") => state_ = 1,
+                    (0, "this" | "one" | "has" | "a" | "lot" | "of" | "aliases") => state_ = 2,
+                    (0, _) => {
+                        return Err(p_.unexpected_arg(arg_));
+                    }
+                    _ => return Err(p_.unexpected_arg(arg_)),
+                },
+            }
+        }
+        Ok(AliasCmd {
+            subcommand: match state_ {
+                1 => AliasCmdCmd::Sub(Sub { count: p_.optional("--count", sub__count)? }),
+                2 => AliasCmdCmd::This(This {}),
+                _ => return Err(p_.subcommand_required()),
+            },
+        })
+    }
+}
+impl AliasCmd {
+    const HELP_: &'static str = "\
+alias-cmd
+  commands with different aliases
+
+OPTIONS:
+    -h, --help
+      Prints help information.
+
+SUBCOMMANDS:
+
+alias-cmd sub | s
+  And even an aliased subcommand!
+
+  OPTIONS:
+    -c, --count <count>
+      Little sanity check to see if this still works as intended
+
+
+alias-cmd this | one | has | a | lot | of | aliases
+";
+}

--- a/crates/xflags/src/lib.rs
+++ b/crates/xflags/src/lib.rs
@@ -163,13 +163,13 @@
 //! ```
 //!
 //! You can create aliases if desired. In this case, `run` can be called as `run`, `r` and `exec`:
-//! 
+//!
 //! ```rust
 //! xflags::xflags! {
 //!     cmd run alias r exec {}
 //! }
 //! ```
-//! 
+//!
 //! Nesting **cmd** is allowed. `xflag` automatically generates boilerplate
 //! enums for subcommands:
 //!

--- a/crates/xflags/src/lib.rs
+++ b/crates/xflags/src/lib.rs
@@ -162,11 +162,12 @@
 //! }
 //! ```
 //!
-//! You can create aliases if desired. In this case, `run` can be called as `run`, `r` and `exec`:
+//! You can create aliases if desired, which is as simple as adding extra names to the `cmd` definition.
+//! In this case, `run` can be called as `run`, `r` and `exec`:
 //!
 //! ```rust
 //! xflags::xflags! {
-//!     cmd run alias r exec {}
+//!     cmd run r exec {}
 //! }
 //! ```
 //!

--- a/crates/xflags/src/lib.rs
+++ b/crates/xflags/src/lib.rs
@@ -162,6 +162,14 @@
 //! }
 //! ```
 //!
+//! You can create aliases if desired. In this case, `run` can be called as `run`, `r` and `exec`:
+//! 
+//! ```rust
+//! xflags::xflags! {
+//!     cmd run alias r exec {}
+//! }
+//! ```
+//! 
 //! Nesting **cmd** is allowed. `xflag` automatically generates boilerplate
 //! enums for subcommands:
 //!


### PR DESCRIPTION
Adds the ability to alias commands to be able to access them by different names. It works like the following:
```rust
xflags::xflags! {
    cmd run alias r exec {}
}
```
where the inital name is optionally followed by the `alias` keyword, followed by at least one identifier. 

The way this works internally is quite simple, all it does it parse the aliases (when encountered) into a `Vec<String>`, and then when matching instead of matching on `cmd.name`, matching all available identifiers with an `|` or sign inbetween.

I didn't update the tests as I didn't feel fully comfortable copy-pasting the current expansion and calling it a day, from my own testing this seemed to work like a charm but there might be cases where you don't like how this works. For example, currently this does not work:
```rust
xflags::xflags! {
    cmd thing {
        cmd thing {}
    }
}
```
because no submodules are created, and the lower level `thing` is considered equivalent to the higher level `thing`. I don't think this is desired, but if it is then there might need to be some changes made, because
```rust
xflags::xflags! {
    cmd thing {
        cmd foo alias thing {}
    }
}
```
works like you would expect: you can call it as `thing thing` and get the inner `thing`'s output.

If there is anything wrong with this, let me know! This is a really neat crate you have here