### PR TITLE
Add a `help` command and generate help messages per command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["xtask/", "crates/*"]
 
 [workspace.package]
-version = "0.3.2" # NB: update the dep!
+version = "0.4.0-pre.1" # NB: update the dep!
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/xflags"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -445,20 +445,17 @@ fn cmd_help_rec(buf: &mut String, cmd: &ast::Cmd, prefix: &str) {
             let short = flag.short.as_ref().map(|it| format!("-{it}, ")).unwrap_or_default();
             let value = flag.val.as_ref().map(|it| format!(" <{}>", it.name)).unwrap_or_default();
             let pre_doc = format!("{short}--{}{value}", flag.name);
-            
             w!(help_buf, "  {:<20} {}\n", pre_doc, flag.doc.as_deref().unwrap_or(""));
         }
     }
     w!(help_buf, "\nCommands:");
     for subcommand in &cmd.subcommands {
         w!(help_buf, "\n  {:<20} {}", subcommand.name, subcommand.doc.as_deref().unwrap_or(""));
-
         let prefix = format!("{}{}__", prefix, subcommand.name);
         cmd_help_rec(buf, subcommand, &prefix);
     }
     w!(help_buf, "\n  {:<20} ", "help");
     w!(help_buf, "Print this message or the help of the given subcommand(s)");
-
     w!(buf, "const HELP_{}: &'static str = \"{help_buf}\";\n", snake(prefix).to_uppercase());
 }
 

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -133,7 +133,7 @@ fn emit_api(buf: &mut String, xflags: &ast::XFlags) {
     w!(buf, "}}\n");
 }
 
-fn emit_impls(buf: &mut String, xflags: &ast::XFlags) -> () {
+fn emit_impls(buf: &mut String, xflags: &ast::XFlags) {
     w!(buf, "impl {} {{\n", xflags.cmd.ident());
     w!(buf, "    fn from_env_or_exit_() -> Self {{\n");
     w!(buf, "        Self::from_env_().unwrap_or_else(|err| err.exit())\n");
@@ -160,7 +160,14 @@ fn emit_parse(buf: &mut String, cmd: &ast::Cmd) {
     emit_locals_rec(buf, &mut prefix, cmd);
     blank_line(buf);
     w!(buf, "let mut state_ = 0u8;\n");
-    w!(buf, "while let Some(arg_) = p_.pop_flag() {{\n");
+
+    // // No while loop needed for command with no items (clippy::never_loop)
+    // if cmd.args.len() + cmd.flags.len() + cmd.subcommands.len() <= 1 {
+    //     w!(buf, "if let Some(arg_) = p_.pop_flag() {{\n");
+    // } else {
+        w!(buf, "while let Some(arg_) = p_.pop_flag() {{\n");
+    // }
+
     w!(buf, "match arg_ {{\n");
     {
         w!(buf, "Ok(flag_) => match (state_, flag_.as_str()) {{\n");
@@ -386,7 +393,7 @@ fn emit_help(buf: &mut String, xflags: &ast::XFlags) {
         buf
     };
     let help = format!("{:?}", help);
-    let help = help.replace("\\n", "\n").replacen("\"", "\"\\\n", 1);
+    let help = help.replace("\\n", "\n").replacen('\"', "\"\\\n", 1);
 
     w!(buf, "const HELP_: &'static str = {help};");
     w!(buf, "}}\n");

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -504,7 +504,7 @@ impl ast::Arity {
         match self {
             ast::Arity::Optional => ("[", "]"),
             ast::Arity::Required => ("<", ">"),
-            ast::Arity::Repeated => ("<", ">..."),
+            ast::Arity::Repeated => ("[", "]..."),
         }
     }
 }

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -444,28 +444,14 @@ fn cmd_help_rec(buf: &mut String, cmd: &ast::Cmd, prefix: &str) {
     }
     if !cmd.args_with_default().is_empty() {
         w!(help_buf, "\nArguments:\n");
-        // let offset =
-        //     cmd.args_with_default().into_iter().map(|a| a.val.name.len() + 4).max().unwrap_or(2);
         for arg in cmd.args_with_default() {
             let (l, r) = arg.arity.brackets();
             let pre_doc = format!("{l}{}{r}", arg.val.name);
-            // w_arg(&mut help_buf, offset, &pre_doc);
             w!(help_buf, "  {:<20} {}\n", pre_doc, arg.doc.as_deref().unwrap_or(""));
         }
     }
     if !cmd.flags_with_default().is_empty() {
         w!(help_buf, "\nOptions:\n");
-        // let offset = cmd
-        //     .flags_with_default()
-        //     .into_iter()
-        //     .map(|flag| {
-        //         flag.short.as_ref().map(|s| s.len() + 3).unwrap_or(0)
-        //             + flag.val.as_ref().map(|v| v.name.len() + 3).unwrap_or(0)
-        //             + flag.name.len()
-        //             + 6
-        //     })
-        //     .max()
-        //     .unwrap_or(6);
         for flag in cmd.flags_with_default() {
             let short = flag.short.as_ref().map(|it| format!("-{it}, ")).unwrap_or_default();
             let value = flag.val.as_ref().map(|it| format!(" <{}>", it.name)).unwrap_or_default();
@@ -483,13 +469,6 @@ fn cmd_help_rec(buf: &mut String, cmd: &ast::Cmd, prefix: &str) {
     w!(help_buf, "Print this message or the help of the given subcommand(s)");
     w!(buf, "const HELP_{}: &'static str = \"{help_buf}\";\n", snake(prefix).to_uppercase());
 }
-
-// fn w_arg(buf: &mut String, n: usize, msg: &str) {
-//     w!(buf, "  {msg}");
-//     for _ in 0..(n.saturating_sub(msg.chars().count() + 2)) {
-//         buf.push(' ')
-//     }
-// }
 
 impl ast::Cmd {
     fn ident(&self) -> String {

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -161,12 +161,12 @@ fn emit_parse(buf: &mut String, cmd: &ast::Cmd) {
     blank_line(buf);
     w!(buf, "let mut state_ = 0u8;\n");
 
-    // // No while loop needed for command with no items (clippy::never_loop)
-    // if cmd.args.len() + cmd.flags.len() + cmd.subcommands.len() <= 1 {
-    //     w!(buf, "if let Some(arg_) = p_.pop_flag() {{\n");
-    // } else {
+    // No while loop needed for command with no items (clippy::never_loop)
+    if cmd.args.len() + cmd.flags.len() + cmd.subcommands.len() <= 1 {
+        w!(buf, "if let Some(arg_) = p_.pop_flag() {{\n");
+    } else {
         w!(buf, "while let Some(arg_) = p_.pop_flag() {{\n");
-    // }
+    }
 
     w!(buf, "match arg_ {{\n");
     {

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -248,13 +248,22 @@ fn emit_match_flag_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
 }
 
 fn emit_match_arg_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
-    w!(buf, "({}, \"help\") => return Err(p_.help(Self::HELP_{})),\n", cmd.idx, snake(prefix).to_uppercase());
-    w!(buf, "({}, \"help\") => return Err(p_.help(Self::HELP_{})),\n", cmd.idx, snake(prefix).to_uppercase());
     for sub in cmd.named_subcommands() {
         let sub_match =
             sub.all_identifiers().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(" | ");
         w!(buf, "({}, {}) => state_ = {},\n", cmd.idx, sub_match, sub.idx);
     }
+
+    if cmd.args.is_empty() {
+        // add `help` subcommand only if command takes no args to make sure it doesn't take precedence
+        w!(
+            buf,
+            "({}, \"help\") => return Err(p_.help(Self::HELP_{})),\n",
+            cmd.idx,
+            snake(prefix).to_uppercase()
+        );
+    }
+
     if !cmd.args.is_empty() || cmd.has_subcommands() {
         w!(buf, "({}, _) => {{\n", cmd.idx);
         for arg in &cmd.args {

--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -172,15 +172,12 @@ fn emit_parse(buf: &mut String, cmd: &ast::Cmd) {
     {
         w!(buf, "Ok(flag_) => match (state_, flag_.as_str()) {{\n");
         emit_match_flag_rec(buf, &mut prefix, cmd);
-        w!(
-            buf,
-            "_ => return Err(p_.unexpected_flag(&flag_).chain(\"\\n\\n\").chain(Self::HELP_)),\n"
-        );
+        w!(buf, "_ => return Err(p_.unexpected_flag(&flag_)),\n");
         w!(buf, "}}\n");
 
         w!(buf, "Err(arg_) => match (state_, arg_.to_str().unwrap_or(\"\")) {{\n");
         emit_match_arg_rec(buf, &mut prefix, cmd);
-        w!(buf, "_ => return Err(p_.unexpected_arg(arg_).chain(\"\\n\\n\").chain(Self::HELP_)),\n");
+        w!(buf, "_ => return Err(p_.unexpected_arg(arg_)),\n");
         w!(buf, "}}\n");
     }
     w!(buf, "}}\n");
@@ -298,11 +295,7 @@ fn emit_match_arg_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
         if let Some(sub) = cmd.default_subcommand() {
             w!(buf, "p_.push_back(Err(arg_)); state_ = {};", sub.idx);
         } else {
-            w!(
-                buf,
-                "return Err(p_.unexpected_arg(arg_).chain(\"\\n\\n\").chain(Self::HELP_{}));",
-                snake(prefix).to_uppercase()
-            );
+            w!(buf, "return Err(p_.unexpected_arg(arg_));");
         }
 
         w!(buf, "}}\n");
@@ -371,11 +364,7 @@ fn emit_record_rec(buf: &mut String, prefix: &mut String, cmd: &ast::Cmd) {
             prefix.truncate(l);
             w!(buf, "),\n");
         }
-        w!(
-            buf,
-            "_ => return Err(p_.subcommand_required().chain(\"\\n\\n\").chain(Self::HELP_{}))",
-            snake(prefix).to_uppercase()
-        );
+        w!(buf, "_ => return Err(p_.subcommand_required())");
         w!(buf, "}}\n");
     }
 

--- a/crates/xflags-macros/src/parse.rs
+++ b/crates/xflags-macros/src/parse.rs
@@ -47,7 +47,7 @@ fn add_help(cmd: &mut ast::Cmd) {
         arity: ast::Arity::Optional,
         name: "help".to_string(),
         short: Some("h".to_string()),
-        doc: Some("Prints help information.".to_string()),
+        doc: Some("Prints help".to_string()),
         val: None,
     };
     cmd.flags.push(help);

--- a/crates/xflags-macros/src/parse.rs
+++ b/crates/xflags-macros/src/parse.rs
@@ -141,7 +141,7 @@ fn cmd_impl(p: &mut Parser, anon: bool) -> Result<ast::Cmd> {
 
     let mut unique_identifiers = std::collections::HashSet::new();
 
-    for ident in res.subcommands.iter().map(|cmd| cmd.all_identifiers()).flatten() {
+    for ident in res.subcommands.iter().flat_map(|cmd| cmd.all_identifiers()) {
         if !unique_identifiers.insert(ident) {
             bail!("`{}` is defined multiple times", ident)
         }
@@ -324,7 +324,8 @@ impl Parser {
     }
     fn at_keyword(&mut self, kw: &str) -> bool {
         match self.ts.last() {
-            Some(TokenTree::Ident(ident)) => &ident.to_string() == kw,
+            #[allow(clippy::cmp_owned)]
+            Some(TokenTree::Ident(ident)) => ident.to_string() == kw,
             _ => false,
         }
     }

--- a/crates/xflags-macros/tests/it/aliases.rs
+++ b/crates/xflags-macros/tests/it/aliases.rs
@@ -66,18 +66,18 @@ impl AliasCmd {
                         sub__count.push(p_.next_value_from_str::<usize>(&flag_)?)
                     }
                     (2, "--help" | "-h") => return Err(p_.help(Self::HELP_THIS__)),
-                    _ => return Err(p_.unexpected_flag(&flag_)),
+                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "sub" | "s") => state_ = 1,
                     (0, "this" | "one" | "has" | "a" | "lot" | "of" | "aliases") => state_ = 2,
                     (0, "help") => return Err(p_.help(Self::HELP_)),
                     (0, _) => {
-                        return Err(p_.unexpected_arg(arg_));
+                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
                     }
                     (1, "help") => return Err(p_.help(Self::HELP_SUB__)),
                     (2, "help") => return Err(p_.help(Self::HELP_THIS__)),
-                    _ => return Err(p_.unexpected_arg(arg_)),
+                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
                 },
             }
         }
@@ -85,7 +85,7 @@ impl AliasCmd {
             subcommand: match state_ {
                 1 => AliasCmdCmd::Sub(Sub { count: p_.optional("--count", sub__count)? }),
                 2 => AliasCmdCmd::This(This {}),
-                _ => return Err(p_.subcommand_required()),
+                _ => return Err(p_.subcommand_required().chain("\n\n").chain(Self::HELP_)),
             },
         })
     }

--- a/crates/xflags-macros/tests/it/aliases.rs
+++ b/crates/xflags-macros/tests/it/aliases.rs
@@ -60,18 +60,23 @@ impl AliasCmd {
         while let Some(arg_) = p_.pop_flag() {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
-                    (0 | 1 | 2, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
+                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
+                    (1, "--help" | "-h") => return Err(p_.help(Self::HELP_SUB__)),
                     (1, "--count" | "-c") => {
                         sub__count.push(p_.next_value_from_str::<usize>(&flag_)?)
                     }
+                    (2, "--help" | "-h") => return Err(p_.help(Self::HELP_THIS__)),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "sub" | "s") => state_ = 1,
                     (0, "this" | "one" | "has" | "a" | "lot" | "of" | "aliases") => state_ = 2,
+                    (0, "help") => return Err(p_.help(Self::HELP_)),
                     (0, _) => {
                         return Err(p_.unexpected_arg(arg_));
                     }
+                    (1, "help") => return Err(p_.help(Self::HELP_SUB__)),
+                    (2, "help") => return Err(p_.help(Self::HELP_THIS__)),
                     _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
@@ -86,24 +91,27 @@ impl AliasCmd {
     }
 }
 impl AliasCmd {
-    const HELP_: &'static str = "\
-alias-cmd
-  commands with different aliases
+    const HELP_SUB__: &'static str = "Usage: sub [-c <count>]
 
-OPTIONS:
-    -h, --help
-      Prints help information.
+And even an aliased subcommand!
 
-SUBCOMMANDS:
+Options:
+  -c, --count <count>  Little sanity check to see if this still works as intended
 
-alias-cmd sub | s
-  And even an aliased subcommand!
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_THIS__: &'static str = "Usage: this
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_: &'static str = "Usage: alias-cmd [-h] <COMMAND>
 
-  OPTIONS:
-    -c, --count <count>
-      Little sanity check to see if this still works as intended
+commands with different aliases
 
+Options:
+  -h, --help           Prints help
 
-alias-cmd this | one | has | a | lot | of | aliases
-";
+Commands:
+  sub                  And even an aliased subcommand!
+  this                 
+  help                 Print this message or the help of the given subcommand(s)";
 }

--- a/crates/xflags-macros/tests/it/aliases.rs
+++ b/crates/xflags-macros/tests/it/aliases.rs
@@ -66,18 +66,18 @@ impl AliasCmd {
                         sub__count.push(p_.next_value_from_str::<usize>(&flag_)?)
                     }
                     (2, "--help" | "-h") => return Err(p_.help(Self::HELP_THIS__)),
-                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "sub" | "s") => state_ = 1,
                     (0, "this" | "one" | "has" | "a" | "lot" | "of" | "aliases") => state_ = 2,
                     (0, "help") => return Err(p_.help(Self::HELP_)),
                     (0, _) => {
-                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
+                        return Err(p_.unexpected_arg(arg_));
                     }
                     (1, "help") => return Err(p_.help(Self::HELP_SUB__)),
                     (2, "help") => return Err(p_.help(Self::HELP_THIS__)),
-                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
         }
@@ -85,7 +85,7 @@ impl AliasCmd {
             subcommand: match state_ {
                 1 => AliasCmdCmd::Sub(Sub { count: p_.optional("--count", sub__count)? }),
                 2 => AliasCmdCmd::This(This {}),
-                _ => return Err(p_.subcommand_required().chain("\n\n").chain(Self::HELP_)),
+                _ => return Err(p_.subcommand_required()),
             },
         })
     }

--- a/crates/xflags-macros/tests/it/empty.rs
+++ b/crates/xflags-macros/tests/it/empty.rs
@@ -44,11 +44,11 @@ impl Empty {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
-                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "help") => return Err(p_.help(Self::HELP_)),
-                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
         }

--- a/crates/xflags-macros/tests/it/empty.rs
+++ b/crates/xflags-macros/tests/it/empty.rs
@@ -40,13 +40,14 @@ impl Empty {
         #![allow(non_snake_case, unused_mut)]
 
         let mut state_ = 0u8;
-        while let Some(arg_) = p_.pop_flag() {
+        if let Some(arg_) = p_.pop_flag() {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
+                    (0, "help") => return Err(p_.help(Self::HELP_)),
                     _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
@@ -55,11 +56,10 @@ impl Empty {
     }
 }
 impl Empty {
-    const HELP_: &'static str = "\
-empty
+    const HELP_: &'static str = "Usage: empty [-h]
+Options:
+  -h, --help           Prints help
 
-OPTIONS:
-    -h, --help
-      Prints help information.
-";
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
 }

--- a/crates/xflags-macros/tests/it/empty.rs
+++ b/crates/xflags-macros/tests/it/empty.rs
@@ -44,11 +44,11 @@ impl Empty {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
-                    _ => return Err(p_.unexpected_flag(&flag_)),
+                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "help") => return Err(p_.help(Self::HELP_)),
-                    _ => return Err(p_.unexpected_arg(arg_)),
+                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
                 },
             }
         }

--- a/crates/xflags-macros/tests/it/help.rs
+++ b/crates/xflags-macros/tests/it/help.rs
@@ -67,7 +67,7 @@ impl Helpful {
                     (0 | 1, "--switch" | "-s") => switch.push(()),
                     (1, "--help" | "-h") => return Err(p_.help(Self::HELP_SUB__)),
                     (1, "--flag" | "-f") => sub__flag.push(()),
-                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "sub") => state_ = 1,
@@ -82,10 +82,10 @@ impl Helpful {
                             *done_ = true;
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
+                        return Err(p_.unexpected_arg(arg_));
                     }
                     (1, "help") => return Err(p_.help(Self::HELP_SUB__)),
-                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
         }
@@ -95,7 +95,7 @@ impl Helpful {
             extra: p_.optional("extra", extra.1)?,
             subcommand: match state_ {
                 1 => HelpfulCmd::Sub(Sub { flag: p_.optional("--flag", sub__flag)?.is_some() }),
-                _ => return Err(p_.subcommand_required().chain("\n\n").chain(Self::HELP_)),
+                _ => return Err(p_.subcommand_required()),
             },
         })
     }

--- a/crates/xflags-macros/tests/it/help.rs
+++ b/crates/xflags-macros/tests/it/help.rs
@@ -67,7 +67,7 @@ impl Helpful {
                     (0 | 1, "--switch" | "-s") => switch.push(()),
                     (1, "--help" | "-h") => return Err(p_.help(Self::HELP_SUB__)),
                     (1, "--flag" | "-f") => sub__flag.push(()),
-                    _ => return Err(p_.unexpected_flag(&flag_)),
+                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "sub") => state_ = 1,
@@ -82,10 +82,10 @@ impl Helpful {
                             *done_ = true;
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_));
+                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
                     }
                     (1, "help") => return Err(p_.help(Self::HELP_SUB__)),
-                    _ => return Err(p_.unexpected_arg(arg_)),
+                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
                 },
             }
         }
@@ -95,7 +95,7 @@ impl Helpful {
             extra: p_.optional("extra", extra.1)?,
             subcommand: match state_ {
                 1 => HelpfulCmd::Sub(Sub { flag: p_.optional("--flag", sub__flag)?.is_some() }),
-                _ => return Err(p_.subcommand_required()),
+                _ => return Err(p_.subcommand_required().chain("\n\n").chain(Self::HELP_)),
             },
         })
     }

--- a/crates/xflags-macros/tests/it/help.rs
+++ b/crates/xflags-macros/tests/it/help.rs
@@ -63,8 +63,9 @@ impl Helpful {
         while let Some(arg_) = p_.pop_flag() {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
+                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     (0 | 1, "--switch" | "-s") => switch.push(()),
-                    (0 | 1, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
+                    (1, "--help" | "-h") => return Err(p_.help(Self::HELP_SUB__)),
                     (1, "--flag" | "-f") => sub__flag.push(()),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
@@ -83,6 +84,7 @@ impl Helpful {
                         }
                         return Err(p_.unexpected_arg(arg_));
                     }
+                    (1, "help") => return Err(p_.help(Self::HELP_SUB__)),
                     _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
@@ -99,38 +101,35 @@ impl Helpful {
     }
 }
 impl Helpful {
-    const HELP_: &'static str = "\
-helpful
-  Does stuff
+    const HELP_SUB__: &'static str = "Usage: sub [-f]
 
-  Helpful stuff.
+And even a subcommand!
 
-ARGS:
-    [src]
-      With an arg.
+Options:
+  -f, --flag           With an optional flag. This has a really long
+description which spans multiple lines.
 
-    [extra]
-      Another arg.
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_: &'static str = "Usage: helpful [src] [extra] -s [-h] <COMMAND>
 
-      This time, we provide some extra info about the
-      arg. Maybe some caveats, or what kinds of
-      values are accepted.
+Does stuff
 
-OPTIONS:
-    -s, --switch
-      And a switch.
+Helpful stuff.
 
-    -h, --help
-      Prints help information.
+Arguments:
+  [src]                With an arg.
+  [extra]              Another arg.
 
-SUBCOMMANDS:
+This time, we provide some extra info about the
+arg. Maybe some caveats, or what kinds of
+values are accepted.
 
-helpful sub
-  And even a subcommand!
+Options:
+  -s, --switch         And a switch.
+  -h, --help           Prints help
 
-  OPTIONS:
-    -f, --flag
-      With an optional flag. This has a really long
-      description which spans multiple lines.
-";
+Commands:
+  sub                  And even a subcommand!
+  help                 Print this message or the help of the given subcommand(s)";
 }

--- a/crates/xflags-macros/tests/it/main.rs
+++ b/crates/xflags-macros/tests/it/main.rs
@@ -77,71 +77,43 @@ fn smoke() {
     check(
         smoke::RustAnalyzer::from_vec,
         "-n 92 --werbose",
-        expect![[r#"
-            unexpected flag: `--werbose`
-
-            Usage: rust-analyzer <workspace> [jobs] [--log-file <path>] [-v]... -n <n> [--data <value>]... [--emoji] [-h]
-
-            LSP server for rust.
-
-            Arguments:
-              <workspace>          
-              [jobs]               Number of concurrent jobs.
-
-            Options:
-              --log-file <path>    Path to log file. By default, logs go to stderr.
-              -v, --verbose        
-              -n, --number <n>     
-              --data <value>       
-              --emoji              
-              -h, --help           Prints help
-
-            Commands:
-              help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["Unknown flag: `--werbose`. Use `help` for more information"],
     );
-    check(smoke::RustAnalyzer::from_vec, "", expect!["flag is required: `--number`"]);
-    check(smoke::RustAnalyzer::from_vec, ".", expect![[r#"flag is required: `--number`"#]]);
+    check(
+        smoke::RustAnalyzer::from_vec,
+        "",
+        expect!["Flag is required: `--number`. Use `help` for more information"],
+    );
+    check(
+        smoke::RustAnalyzer::from_vec,
+        ".",
+        expect!["Flag is required: `--number`. Use `help` for more information"],
+    );
     check(smoke::RustAnalyzer::from_vec, "-n", expect![[r#"expected a value for `-n`"#]]);
-    check(smoke::RustAnalyzer::from_vec, "-n 92", expect!["flag is required: `workspace`"]);
+    check(
+        smoke::RustAnalyzer::from_vec,
+        "-n 92",
+        expect!["Flag is required: `workspace`. Use `help` for more information"],
+    );
     check(
         smoke::RustAnalyzer::from_vec,
         "-n lol",
-        expect![[r#"can't parse `-n`, invalid digit found in string"#]],
+        expect!["Can't parse `-n`, invalid digit found in string"],
     );
     check(
         smoke::RustAnalyzer::from_vec,
         "-n 1 -n 2 .",
-        expect![[r#"flag specified more than once: `--number`"#]],
+        expect!["Flag specified more than once: `--number`"],
     );
     check(
         smoke::RustAnalyzer::from_vec,
         "-n 1 . 92 lol",
-        expect![[r#"
-            unexpected argument: "lol"
-
-            Usage: rust-analyzer <workspace> [jobs] [--log-file <path>] [-v]... -n <n> [--data <value>]... [--emoji] [-h]
-
-            LSP server for rust.
-
-            Arguments:
-              <workspace>          
-              [jobs]               Number of concurrent jobs.
-
-            Options:
-              --log-file <path>    Path to log file. By default, logs go to stderr.
-              -v, --verbose        
-              -n, --number <n>     
-              --data <value>       
-              --emoji              
-              -h, --help           Prints help
-
-            Commands:
-              help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["Unknown command: `lol`. Use `help` for more information"],
     );
     check(
         smoke::RustAnalyzer::from_vec,
         "-n 1 . --emoji --emoji",
-        expect![[r#"flag specified more than once: `--emoji`"#]],
+        expect!["Flag specified more than once: `--emoji`"],
     );
 }
 
@@ -250,18 +222,7 @@ fn subcommands() {
     check(
         subcommands::RustAnalyzer::from_vec,
         "",
-        expect![[r#"
-        subcommand is required
-
-        Usage: rust-analyzer [-v]... [-h] <COMMAND>
-        Options:
-          -v, --verbose        
-          -h, --help           Prints help
-
-        Commands:
-          server               
-          analysis-stats       
-          help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["A subcommand is required. Use `help` for more information"],
     );
 }
 
@@ -289,34 +250,12 @@ fn subcommand_flag_inheritance() {
     check(
         subcommands::RustAnalyzer::from_vec,
         "analysis-stats --verbose --dir .",
-        expect![[r#"
-            unexpected flag: `--dir`
-
-            Usage: rust-analyzer [-v]... [-h] <COMMAND>
-            Options:
-              -v, --verbose        
-              -h, --help           Prints help
-
-            Commands:
-              server               
-              analysis-stats       
-              help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["Unknown flag: `--dir`. Use `help` for more information"],
     );
     check(
         subcommands::RustAnalyzer::from_vec,
         "--dir . server",
-        expect![[r#"
-            unexpected flag: `--dir`
-
-            Usage: rust-analyzer [-v]... [-h] <COMMAND>
-            Options:
-              -v, --verbose        
-              -h, --help           Prints help
-
-            Commands:
-              server               
-              analysis-stats       
-              help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["Unknown flag: `--dir`. Use `help` for more information"],
     );
 }
 
@@ -367,37 +306,12 @@ fn edge_cases() {
     check(
         subcommands::RustAnalyzer::from_vec,
         "-- -v server",
-        expect![[r#"
-            unexpected argument: "-v"
-
-            Usage: rust-analyzer [-v]... [-h] <COMMAND>
-            Options:
-              -v, --verbose        
-              -h, --help           Prints help
-
-            Commands:
-              server               
-              analysis-stats       
-              help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["Unknown command: `-v`. Use `help` for more information"],
     );
     check(
         repeated_pos::RepeatedPos::from_vec,
         "pos 1 prog -j",
-        expect![[r#"
-        unexpected flag: `-j`
-
-        Usage: RepeatedPos <a> [b] [c] [rest]... [-h]
-        Arguments:
-          <a>                  
-          [b]                  
-          [c]                  
-          [rest]...            
-
-        Options:
-          -h, --help           Prints help
-
-        Commands:
-          help                 Print this message or the help of the given subcommand(s)"#]],
+        expect!["Unknown flag: `-j`. Use `help` for more information"],
     );
     check(
         repeated_pos::RepeatedPos::from_vec,

--- a/crates/xflags-macros/tests/it/main.rs
+++ b/crates/xflags-macros/tests/it/main.rs
@@ -77,7 +77,27 @@ fn smoke() {
     check(
         smoke::RustAnalyzer::from_vec,
         "-n 92 --werbose",
-        expect![[r#"unexpected flag: `--werbose`"#]],
+        expect![[r#"
+            unexpected flag: `--werbose`
+
+            Usage: rust-analyzer <workspace> [jobs] [--log-file <path>] [-v]... -n <n> [--data <value>]... [--emoji] [-h]
+
+            LSP server for rust.
+
+            Arguments:
+              <workspace>          
+              [jobs]               Number of concurrent jobs.
+
+            Options:
+              --log-file <path>    Path to log file. By default, logs go to stderr.
+              -v, --verbose        
+              -n, --number <n>     
+              --data <value>       
+              --emoji              
+              -h, --help           Prints help
+
+            Commands:
+              help                 Print this message or the help of the given subcommand(s)"#]],
     );
     check(smoke::RustAnalyzer::from_vec, "", expect!["flag is required: `--number`"]);
     check(smoke::RustAnalyzer::from_vec, ".", expect![[r#"flag is required: `--number`"#]]);
@@ -96,7 +116,27 @@ fn smoke() {
     check(
         smoke::RustAnalyzer::from_vec,
         "-n 1 . 92 lol",
-        expect![[r#"unexpected argument: "lol""#]],
+        expect![[r#"
+            unexpected argument: "lol"
+
+            Usage: rust-analyzer <workspace> [jobs] [--log-file <path>] [-v]... -n <n> [--data <value>]... [--emoji] [-h]
+
+            LSP server for rust.
+
+            Arguments:
+              <workspace>          
+              [jobs]               Number of concurrent jobs.
+
+            Options:
+              --log-file <path>    Path to log file. By default, logs go to stderr.
+              -v, --verbose        
+              -n, --number <n>     
+              --data <value>       
+              --emoji              
+              -h, --help           Prints help
+
+            Commands:
+              help                 Print this message or the help of the given subcommand(s)"#]],
     );
     check(
         smoke::RustAnalyzer::from_vec,
@@ -207,7 +247,22 @@ fn subcommands() {
         "#]],
     );
 
-    check(subcommands::RustAnalyzer::from_vec, "", expect![[r#"subcommand is required"#]]);
+    check(
+        subcommands::RustAnalyzer::from_vec,
+        "",
+        expect![[r#"
+        subcommand is required
+
+        Usage: rust-analyzer [-v]... [-h] <COMMAND>
+        Options:
+          -v, --verbose        
+          -h, --help           Prints help
+
+        Commands:
+          server               
+          analysis-stats       
+          help                 Print this message or the help of the given subcommand(s)"#]],
+    );
 }
 
 #[test]
@@ -234,12 +289,34 @@ fn subcommand_flag_inheritance() {
     check(
         subcommands::RustAnalyzer::from_vec,
         "analysis-stats --verbose --dir .",
-        expect!["unexpected flag: `--dir`"],
+        expect![[r#"
+            unexpected flag: `--dir`
+
+            Usage: rust-analyzer [-v]... [-h] <COMMAND>
+            Options:
+              -v, --verbose        
+              -h, --help           Prints help
+
+            Commands:
+              server               
+              analysis-stats       
+              help                 Print this message or the help of the given subcommand(s)"#]],
     );
     check(
         subcommands::RustAnalyzer::from_vec,
         "--dir . server",
-        expect!["unexpected flag: `--dir`"],
+        expect![[r#"
+            unexpected flag: `--dir`
+
+            Usage: rust-analyzer [-v]... [-h] <COMMAND>
+            Options:
+              -v, --verbose        
+              -h, --help           Prints help
+
+            Commands:
+              server               
+              analysis-stats       
+              help                 Print this message or the help of the given subcommand(s)"#]],
     );
 }
 
@@ -290,9 +367,38 @@ fn edge_cases() {
     check(
         subcommands::RustAnalyzer::from_vec,
         "-- -v server",
-        expect![[r#"unexpected argument: "-v""#]],
+        expect![[r#"
+            unexpected argument: "-v"
+
+            Usage: rust-analyzer [-v]... [-h] <COMMAND>
+            Options:
+              -v, --verbose        
+              -h, --help           Prints help
+
+            Commands:
+              server               
+              analysis-stats       
+              help                 Print this message or the help of the given subcommand(s)"#]],
     );
-    check(repeated_pos::RepeatedPos::from_vec, "pos 1 prog -j", expect!["unexpected flag: `-j`"]);
+    check(
+        repeated_pos::RepeatedPos::from_vec,
+        "pos 1 prog -j",
+        expect![[r#"
+        unexpected flag: `-j`
+
+        Usage: RepeatedPos <a> [b] [c] [rest]... [-h]
+        Arguments:
+          <a>                  
+          [b]                  
+          [c]                  
+          [rest]...            
+
+        Options:
+          -h, --help           Prints help
+
+        Commands:
+          help                 Print this message or the help of the given subcommand(s)"#]],
+    );
     check(
         repeated_pos::RepeatedPos::from_vec,
         "pos 1 -- prog -j",

--- a/crates/xflags-macros/tests/it/repeated_pos.rs
+++ b/crates/xflags-macros/tests/it/repeated_pos.rs
@@ -53,7 +53,7 @@ impl RepeatedPos {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
-                    _ => return Err(p_.unexpected_flag(&flag_)),
+                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, _) => {
@@ -76,9 +76,9 @@ impl RepeatedPos {
                             buf_.push(arg_.into());
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_));
+                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
                     }
-                    _ => return Err(p_.unexpected_arg(arg_)),
+                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
                 },
             }
         }

--- a/crates/xflags-macros/tests/it/repeated_pos.rs
+++ b/crates/xflags-macros/tests/it/repeated_pos.rs
@@ -53,7 +53,7 @@ impl RepeatedPos {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
                     (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
-                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, _) => {
@@ -76,9 +76,9 @@ impl RepeatedPos {
                             buf_.push(arg_.into());
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
+                        return Err(p_.unexpected_arg(arg_));
                     }
-                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
         }

--- a/crates/xflags-macros/tests/it/repeated_pos.rs
+++ b/crates/xflags-macros/tests/it/repeated_pos.rs
@@ -91,20 +91,16 @@ impl RepeatedPos {
     }
 }
 impl RepeatedPos {
-    const HELP_: &'static str = "\
-RepeatedPos
+    const HELP_: &'static str = "Usage: RepeatedPos <a> [b] [c] [rest]... [-h]
+Arguments:
+  <a>                  
+  [b]                  
+  [c]                  
+  [rest]...            
 
-ARGS:
-    <a>
+Options:
+  -h, --help           Prints help
 
-    [b]
-
-    [c]
-
-    <rest>...
-
-OPTIONS:
-    -h, --help
-      Prints help information.
-";
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
 }

--- a/crates/xflags-macros/tests/it/smoke.rs
+++ b/crates/xflags-macros/tests/it/smoke.rs
@@ -59,12 +59,12 @@ impl RustAnalyzer {
         while let Some(arg_) = p_.pop_flag() {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
+                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     (0, "--log-file") => log_file.push(p_.next_value(&flag_)?.into()),
                     (0, "--verbose" | "-v") => verbose.push(()),
                     (0, "--number" | "-n") => number.push(p_.next_value_from_str::<u32>(&flag_)?),
                     (0, "--data") => data.push(p_.next_value(&flag_)?.into()),
                     (0, "--emoji") => emoji.push(()),
-                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
@@ -97,29 +97,22 @@ impl RustAnalyzer {
     }
 }
 impl RustAnalyzer {
-    const HELP_: &'static str = "\
-rust-analyzer
-  LSP server for rust.
+    const HELP_: &'static str = "Usage: rust-analyzer <workspace> [jobs] [--log-file <path>] [-v]... -n <n> [--data <value>]... [--emoji] [-h]
 
-ARGS:
-    <workspace>
+LSP server for rust.
 
-    [jobs]
-      Number of concurrent jobs.
+Arguments:
+  <workspace>          
+  [jobs]               Number of concurrent jobs.
 
-OPTIONS:
-    --log-file <path>
-      Path to log file. By default, logs go to stderr.
+Options:
+  --log-file <path>    Path to log file. By default, logs go to stderr.
+  -v, --verbose        
+  -n, --number <n>     
+  --data <value>       
+  --emoji              
+  -h, --help           Prints help
 
-    -v, --verbose
-
-    -n, --number <n>
-
-    --data <value>
-
-    --emoji
-
-    -h, --help
-      Prints help information.
-";
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
 }

--- a/crates/xflags-macros/tests/it/smoke.rs
+++ b/crates/xflags-macros/tests/it/smoke.rs
@@ -65,7 +65,7 @@ impl RustAnalyzer {
                     (0, "--number" | "-n") => number.push(p_.next_value_from_str::<u32>(&flag_)?),
                     (0, "--data") => data.push(p_.next_value(&flag_)?.into()),
                     (0, "--emoji") => emoji.push(()),
-                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, _) => {
@@ -79,9 +79,9 @@ impl RustAnalyzer {
                             *done_ = true;
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
+                        return Err(p_.unexpected_arg(arg_));
                     }
-                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
         }

--- a/crates/xflags-macros/tests/it/smoke.rs
+++ b/crates/xflags-macros/tests/it/smoke.rs
@@ -65,7 +65,7 @@ impl RustAnalyzer {
                     (0, "--number" | "-n") => number.push(p_.next_value_from_str::<u32>(&flag_)?),
                     (0, "--data") => data.push(p_.next_value(&flag_)?.into()),
                     (0, "--emoji") => emoji.push(()),
-                    _ => return Err(p_.unexpected_flag(&flag_)),
+                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, _) => {
@@ -79,9 +79,9 @@ impl RustAnalyzer {
                             *done_ = true;
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_));
+                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
                     }
-                    _ => return Err(p_.unexpected_arg(arg_)),
+                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
                 },
             }
         }

--- a/crates/xflags-macros/tests/it/subcommands.rs
+++ b/crates/xflags-macros/tests/it/subcommands.rs
@@ -97,14 +97,14 @@ impl RustAnalyzer {
                     (3, "--help" | "-h") => return Err(p_.help(Self::HELP_SERVER__WATCH__)),
                     (4, "--help" | "-h") => return Err(p_.help(Self::HELP_ANALYSIS_STATS__)),
                     (4, "--parallel") => analysis_stats__parallel.push(()),
-                    _ => return Err(p_.unexpected_flag(&flag_)),
+                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "server") => state_ = 1,
                     (0, "analysis-stats") => state_ = 4,
                     (0, "help") => return Err(p_.help(Self::HELP_)),
                     (0, _) => {
-                        return Err(p_.unexpected_arg(arg_));
+                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
                     }
                     (1, "watch") => state_ = 3,
                     (1, "help") => return Err(p_.help(Self::HELP_SERVER__)),
@@ -120,9 +120,12 @@ impl RustAnalyzer {
                             *done_ = true;
                             continue;
                         }
-                        return Err(p_.unexpected_arg(arg_));
+                        return Err(p_
+                            .unexpected_arg(arg_)
+                            .chain("\n\n")
+                            .chain(Self::HELP_ANALYSIS_STATS__));
                     }
-                    _ => return Err(p_.unexpected_arg(arg_)),
+                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
                 },
             }
         }
@@ -137,14 +140,19 @@ impl RustAnalyzer {
                             log: p_.optional("--log", server__launch__log)?.is_some(),
                         }),
                         3 => ServerCmd::Watch(Watch {}),
-                        _ => return Err(p_.subcommand_required()),
+                        _ => {
+                            return Err(p_
+                                .subcommand_required()
+                                .chain("\n\n")
+                                .chain(Self::HELP_SERVER__))
+                        }
                     },
                 }),
                 4 => RustAnalyzerCmd::AnalysisStats(AnalysisStats {
                     parallel: p_.optional("--parallel", analysis_stats__parallel)?.is_some(),
                     path: p_.required("path", analysis_stats__path.1)?,
                 }),
-                _ => return Err(p_.subcommand_required()),
+                _ => return Err(p_.subcommand_required().chain("\n\n").chain(Self::HELP_)),
             },
         })
     }

--- a/crates/xflags-macros/tests/it/subcommands.rs
+++ b/crates/xflags-macros/tests/it/subcommands.rs
@@ -97,14 +97,14 @@ impl RustAnalyzer {
                     (3, "--help" | "-h") => return Err(p_.help(Self::HELP_SERVER__WATCH__)),
                     (4, "--help" | "-h") => return Err(p_.help(Self::HELP_ANALYSIS_STATS__)),
                     (4, "--parallel") => analysis_stats__parallel.push(()),
-                    _ => return Err(p_.unexpected_flag(&flag_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "server") => state_ = 1,
                     (0, "analysis-stats") => state_ = 4,
                     (0, "help") => return Err(p_.help(Self::HELP_)),
                     (0, _) => {
-                        return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_));
+                        return Err(p_.unexpected_arg(arg_));
                     }
                     (1, "watch") => state_ = 3,
                     (1, "help") => return Err(p_.help(Self::HELP_SERVER__)),
@@ -120,12 +120,9 @@ impl RustAnalyzer {
                             *done_ = true;
                             continue;
                         }
-                        return Err(p_
-                            .unexpected_arg(arg_)
-                            .chain("\n\n")
-                            .chain(Self::HELP_ANALYSIS_STATS__));
+                        return Err(p_.unexpected_arg(arg_));
                     }
-                    _ => return Err(p_.unexpected_arg(arg_).chain("\n\n").chain(Self::HELP_)),
+                    _ => return Err(p_.unexpected_arg(arg_)),
                 },
             }
         }
@@ -140,19 +137,14 @@ impl RustAnalyzer {
                             log: p_.optional("--log", server__launch__log)?.is_some(),
                         }),
                         3 => ServerCmd::Watch(Watch {}),
-                        _ => {
-                            return Err(p_
-                                .subcommand_required()
-                                .chain("\n\n")
-                                .chain(Self::HELP_SERVER__))
-                        }
+                        _ => return Err(p_.subcommand_required()),
                     },
                 }),
                 4 => RustAnalyzerCmd::AnalysisStats(AnalysisStats {
                     parallel: p_.optional("--parallel", analysis_stats__parallel)?.is_some(),
                     path: p_.required("path", analysis_stats__path.1)?,
                 }),
-                _ => return Err(p_.subcommand_required().chain("\n\n").chain(Self::HELP_)),
+                _ => return Err(p_.subcommand_required()),
             },
         })
     }

--- a/crates/xflags-macros/tests/it/subcommands.rs
+++ b/crates/xflags-macros/tests/it/subcommands.rs
@@ -84,28 +84,36 @@ impl RustAnalyzer {
         while let Some(arg_) = p_.pop_flag() {
             match arg_ {
                 Ok(flag_) => match (state_, flag_.as_str()) {
+                    (0, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
                     (0 | 1 | 2 | 3 | 4, "--verbose" | "-v") => verbose.push(()),
-                    (0 | 1 | 2 | 3 | 4, "--help" | "-h") => return Err(p_.help(Self::HELP_)),
+                    (1, "--help" | "-h") => return Err(p_.help(Self::HELP_SERVER__)),
                     (1 | 2 | 3, "--dir") => server__dir.push(p_.next_value(&flag_)?.into()),
                     (1, _) => {
                         p_.push_back(Ok(flag_));
                         state_ = 2;
                     }
+                    (2, "--help" | "-h") => return Err(p_.help(Self::HELP_SERVER__LAUNCH__)),
                     (2, "--log") => server__launch__log.push(()),
+                    (3, "--help" | "-h") => return Err(p_.help(Self::HELP_SERVER__WATCH__)),
+                    (4, "--help" | "-h") => return Err(p_.help(Self::HELP_ANALYSIS_STATS__)),
                     (4, "--parallel") => analysis_stats__parallel.push(()),
                     _ => return Err(p_.unexpected_flag(&flag_)),
                 },
                 Err(arg_) => match (state_, arg_.to_str().unwrap_or("")) {
                     (0, "server") => state_ = 1,
                     (0, "analysis-stats") => state_ = 4,
+                    (0, "help") => return Err(p_.help(Self::HELP_)),
                     (0, _) => {
                         return Err(p_.unexpected_arg(arg_));
                     }
                     (1, "watch") => state_ = 3,
+                    (1, "help") => return Err(p_.help(Self::HELP_SERVER__)),
                     (1, _) => {
                         p_.push_back(Err(arg_));
                         state_ = 2;
                     }
+                    (2, "help") => return Err(p_.help(Self::HELP_SERVER__LAUNCH__)),
+                    (3, "help") => return Err(p_.help(Self::HELP_SERVER__WATCH__)),
                     (4, _) => {
                         if let (done_ @ false, buf_) = &mut analysis_stats__path {
                             buf_.push(arg_.into());
@@ -142,34 +150,40 @@ impl RustAnalyzer {
     }
 }
 impl RustAnalyzer {
-    const HELP_: &'static str = "\
-rust-analyzer
+    const HELP_SERVER__LAUNCH__: &'static str = "Usage: launch [--log]
+Options:
+  --log                
 
-OPTIONS:
-    -v, --verbose
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_SERVER__WATCH__: &'static str = "Usage: watch
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_SERVER__: &'static str = "Usage: server [--dir <path>] [--log] <COMMAND>
+Options:
+  --dir <path>         
+  --log                
 
-    -h, --help
-      Prints help information.
+Commands:
+  launch               
+  watch                
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_ANALYSIS_STATS__: &'static str = "Usage: analysis-stats <path> [--parallel]
+Arguments:
+  <path>               
 
-SUBCOMMANDS:
+Options:
+  --parallel           
 
-rust-analyzer server
+Commands:
+  help                 Print this message or the help of the given subcommand(s)";
+    const HELP_: &'static str = "Usage: rust-analyzer [-v]... [-h] <COMMAND>
+Options:
+  -v, --verbose        
+  -h, --help           Prints help
 
-  OPTIONS:
-    --dir <path>
-
-    --log
-
-
-rust-analyzer server watch
-
-
-rust-analyzer analysis-stats
-
-  ARGS:
-    <path>
-
-  OPTIONS:
-    --parallel
-";
+Commands:
+  server               
+  analysis-stats       
+  help                 Print this message or the help of the given subcommand(s)";
 }

--- a/crates/xflags/Cargo.toml
+++ b/crates/xflags/Cargo.toml
@@ -9,4 +9,4 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-xflags-macros = { path = "../xflags-macros", version = "=0.3.2" }
+xflags-macros = { path = "../xflags-macros", version = "=0.4.0-pre.1" }

--- a/crates/xflags/examples/non-utf8.rs
+++ b/crates/xflags/examples/non-utf8.rs
@@ -17,8 +17,8 @@ fn main() {
     use std::os::unix::ffi::OsStringExt;
 
     let flags = flags::Cmd::from_vec(vec![
-        OsString::from_vec(vec![254].into()),
-        OsString::from_vec(vec![255].into()),
+        OsString::from_vec(vec![254]),
+        OsString::from_vec(vec![255]),
         "utf8".into(),
     ]);
 

--- a/crates/xflags/src/lib.rs
+++ b/crates/xflags/src/lib.rs
@@ -375,6 +375,12 @@ impl Error {
             std::process::exit(2)
         }
     }
+
+    /// Appends to the contained message
+    pub fn chain(mut self, msg: &str) -> Self {
+        self.msg.push_str(msg);
+        self
+    }
 }
 
 /// Private impl details for macros.

--- a/crates/xflags/src/lib.rs
+++ b/crates/xflags/src/lib.rs
@@ -44,16 +44,16 @@
 //! help:
 //!
 //! ```text
-//! ARGS:
-//!     <path>
-//!       File or directory to remove
+//! Usage:  <path> [-r] [-h]
+//! Arguments:
+//!   <path>               File or directory to remove
 //!
-//! OPTIONS:
-//!     -r, --recursive
-//!       Remove directories and their contents recursively.
+//! Options:
+//!   -r, --recursive      Remove directories and their contents recursively.
+//!   -h, --help           Prints help
 //!
-//!     -h, --help
-//!       Prints help information.
+//! Commands:
+//!   help                 Print this message or the help of the given subcommand(s)
 //! ```
 //!
 //! For larger programs, you'd typically want to use `xflags!` macro, which

--- a/crates/xflags/src/rt.rs
+++ b/crates/xflags/src/rt.rs
@@ -21,17 +21,14 @@ pub struct Parser {
 
 impl Parser {
     pub fn new(mut args: Vec<OsString>) -> Self {
-        args.reverse();
-
-        // parse `help` command last when encountered first to be able to do `help <commands>` without creating
-        // a bunch of leafs in the parse tree for it
-        match args.pop() {
-            Some(arg) => match arg.to_str().unwrap_or("") {
-                "help" => args.insert(0, "--help".into()),
-                _ => args.push(arg),
-            },
-            _ => {}
+        // parse `help` command last when encountered somewhere along the way to be able to do
+        // `help <commands>` or `cmd help sub` without creating a bunch of leafs in the parse tree for it
+        if let Some((i, _)) = args.iter().enumerate().find(|(_, arg)| *arg == "help") {
+            args.remove(i);
+            args.push("--help".into())
         }
+
+        args.reverse();
 
         Self { after_double_dash: false, rargs: args }
     }

--- a/crates/xflags/src/rt.rs
+++ b/crates/xflags/src/rt.rs
@@ -22,6 +22,17 @@ pub struct Parser {
 impl Parser {
     pub fn new(mut args: Vec<OsString>) -> Self {
         args.reverse();
+
+        // parse `help` command last when encountered first to be able to do `help <commands>` without creating
+        // a bunch of leafs in the parse tree for it
+        match args.pop() {
+            Some(arg) => match arg.to_str().unwrap_or("") {
+                "help" => args.insert(0, "--help".into()),
+                _ => args.push(arg),
+            },
+            _ => {}
+        }
+
         Self { after_double_dash: false, rargs: args }
     }
 

--- a/crates/xflags/src/rt.rs
+++ b/crates/xflags/src/rt.rs
@@ -87,23 +87,28 @@ impl Parser {
         T::Err: fmt::Display,
     {
         match value.into_string() {
-            Ok(str) => str.parse::<T>().map_err(|err| format_err!("can't parse `{flag}`, {err}")),
+            Ok(str) => str.parse::<T>().map_err(|err| format_err!("Can't parse `{flag}`, {err}")),
             Err(it) => {
-                bail!("can't parse `{flag}`, invalid utf8: {it:?}")
+                bail!("Can't parse `{flag}`, invalid utf8: {it:?}")
             }
         }
     }
 
     pub fn unexpected_flag(&self, flag: &str) -> Error {
-        format_err!("unexpected flag: `{flag}`")
+        format_err!("Unknown flag: `{flag}`. Use `help` for more information")
     }
 
     pub fn unexpected_arg(&self, arg: OsString) -> Error {
-        format_err!("unexpected argument: {arg:?}")
+        // `to_string_lossy()` seems appropriate here but OsString's debug implementation actually
+        // escapes codes that are not valid utf-8, rather than replace them with `FFFD`
+        let dbg = format!("{arg:?}");
+        let arg = dbg.trim_matches('"');
+
+        format_err!("Unknown command: `{arg}`. Use `help` for more information")
     }
 
     pub fn subcommand_required(&self) -> Error {
-        format_err!("subcommand is required")
+        format_err!("A subcommand is required. Use `help` for more information")
     }
 
     pub fn help(&self, help: &'static str) -> Error {
@@ -112,15 +117,17 @@ impl Parser {
 
     pub fn optional<T>(&self, flag: &str, mut vals: Vec<T>) -> Result<Option<T>> {
         if vals.len() > 1 {
-            bail!("flag specified more than once: `{flag}`")
+            bail!("Flag specified more than once: `{flag}`")
         }
         Ok(vals.pop())
     }
 
     pub fn required<T>(&self, flag: &str, mut vals: Vec<T>) -> Result<T> {
         if vals.len() > 1 {
-            bail!("flag specified more than once: `{flag}`")
+            bail!("Flag specified more than once: `{flag}`")
         }
-        vals.pop().ok_or_else(|| format_err!("flag is required: `{flag}`"))
+        vals.pop().ok_or_else(|| {
+            format_err!("Flag is required: `{flag}`. Use `help` for more information")
+        })
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> xshell::Result<()> {
 
         let current_branch = cmd!(sh, "git branch --show-current").read()?;
         let tag_exists =
-            cmd!(sh, "git tag --list").read()?.split_ascii_whitespace().any(|it| it == &tag);
+            cmd!(sh, "git tag --list").read()?.split_ascii_whitespace().any(|it| it == tag);
 
         if current_branch == "master" && !tag_exists {
             cmd!(sh, "git tag v{version}").run()?;


### PR DESCRIPTION
xflags is pretty great! What bothers me though is that currently the generated help message gets long quickly and doesn't look good. Using the [fuchsia help message guidelines](https://fuchsia.dev/fuchsia-src/development/api/cli_help) and Clap's default help messages I made it so it now generates a help message for each command.

Implemented are:
- a `help` command for each individual command that can be used as `help <commands>` or `<commands> help`
- Help messages for each individual command, without changing any `xflags!` macro syntax

Something to note:
Currently, it aligns command/arg/flag docs to 2 space indents + 20 characters. That fits something like `-c, --count <count>` which is probably good enough for most use cases, but Clap obviously does it prettier where it's the longest command + 2 spaces. There is probably a good way to do this but I couldn't really find something that wasn't collecting everything midway and pushing a bunch of individual spaces to the buffer. Maybe that's fine, I'm not sure.

I've tested this quite a lot and it _seems_ it can't really break, but if you find something be sure to let me know :)

edit: one thing I completely missed is printing help information when an unexpected argument is encountered, I'll fix that up