### PR TITLE
Fix help generation showing the default command

### DIFF
--- a/crates/xflags-macros/src/emit.rs
+++ b/crates/xflags-macros/src/emit.rs
@@ -431,17 +431,19 @@ fn cmd_help_rec(buf: &mut String, cmd: &ast::Cmd, prefix: &str) {
     if let Some(doc) = &cmd.doc {
         w!(help_buf, "\n\n{}\n", doc);
     }
-    if !cmd.args_with_default().is_empty() {
+    let args_with_default = cmd.args_with_default();
+    if !args_with_default.is_empty() {
         w!(help_buf, "\nArguments:\n");
-        for arg in cmd.args_with_default() {
+        for arg in args_with_default {
             let (l, r) = arg.arity.brackets();
             let pre_doc = format!("{l}{}{r}", arg.val.name);
             w!(help_buf, "  {:<20} {}\n", pre_doc, arg.doc.as_deref().unwrap_or(""));
         }
     }
-    if !cmd.flags_with_default().is_empty() {
+    let flags_with_default = cmd.flags_with_default();
+    if !flags_with_default.is_empty() {
         w!(help_buf, "\nOptions:\n");
-        for flag in cmd.flags_with_default() {
+        for flag in flags_with_default {
             let short = flag.short.as_ref().map(|it| format!("-{it}, ")).unwrap_or_default();
             let value = flag.val.as_ref().map(|it| format!(" <{}>", it.name)).unwrap_or_default();
             let pre_doc = format!("{short}--{}{value}", flag.name);
@@ -449,8 +451,10 @@ fn cmd_help_rec(buf: &mut String, cmd: &ast::Cmd, prefix: &str) {
         }
     }
     w!(help_buf, "\nCommands:");
-    for subcommand in &cmd.subcommands {
+    for subcommand in cmd.named_subcommands() {
         w!(help_buf, "\n  {:<20} {}", subcommand.name, subcommand.doc.as_deref().unwrap_or(""));
+    }
+    for subcommand in &cmd.subcommands {
         let prefix = format!("{}{}__", prefix, subcommand.name);
         cmd_help_rec(buf, subcommand, &prefix);
     }

--- a/crates/xflags-macros/tests/it/subcommands.rs
+++ b/crates/xflags-macros/tests/it/subcommands.rs
@@ -165,7 +165,6 @@ Options:
   --log                
 
 Commands:
-  launch               
   watch                
   help                 Print this message or the help of the given subcommand(s)";
     const HELP_ANALYSIS_STATS__: &'static str = "Usage: analysis-stats <path> [--parallel]


### PR DESCRIPTION
Fixes default commands showing up by their name in help messages. This implementation is technically wasteful because it still generates the parsing logic and `<subcommand name> --help` message. I couldn't figure out a way to get rid of this waste and errors weren't helpful trying to fix it, but considering rustc probably throws out much of this anyway as unused or unreachable it's probably fine.